### PR TITLE
Update Gemini 2.0 to not use exp and use the normal one instead. Exp …

### DIFF
--- a/src/v1/gemini.rs
+++ b/src/v1/gemini.rs
@@ -111,7 +111,7 @@ impl fmt::Display for Model {
 
             #[cfg(feature = "beta")]
             #[cfg_attr(docsrs, doc(cfg(feature = "beta")))]
-            Model::Gemini2_0Flash => write!(f, "gemini-2.0-flash-exp"),
+            Model::Gemini2_0Flash => write!(f, "gemini-2.0-flash"),
 
             #[cfg(feature = "beta")]
             #[cfg_attr(docsrs, doc(cfg(feature = "beta")))]


### PR DESCRIPTION
…model has a RPM 10.